### PR TITLE
Add jquery hoverintent to repo

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,6 +17,7 @@
     <script src="js/jquery.css3.min.js"></script>
     <script src="js/jquery.easing.js"></script>
     <script src="js/localstorage.js"></script>
+    <script src="js/jquery.hoverIntent.min.js"></script>
     <script src="js/system.js"></script>
 
     <div id="message"></div>

--- a/js/jquery.hoverIntent.min.js
+++ b/js/jquery.hoverIntent.min.js
@@ -1,0 +1,9 @@
+/**
+* hoverIntent r6 // 2011.02.26 // jQuery 1.5.1+
+* <http://cherne.net/brian/resources/jquery.hoverIntent.html>
+* 
+* @param  f  onMouseOver function || An object with configuration options
+* @param  g  onMouseOut function  || Nothing (use configuration options object)
+* @author    Brian Cherne brian(at)cherne(dot)net
+*/
+(function($){$.fn.hoverIntent=function(f,g){var cfg={sensitivity:7,interval:100,timeout:0};cfg=$.extend(cfg,g?{over:f,out:g}:f);var cX,cY,pX,pY;var track=function(ev){cX=ev.pageX;cY=ev.pageY};var compare=function(ev,ob){ob.hoverIntent_t=clearTimeout(ob.hoverIntent_t);if((Math.abs(pX-cX)+Math.abs(pY-cY))<cfg.sensitivity){$(ob).unbind("mousemove",track);ob.hoverIntent_s=1;return cfg.over.apply(ob,[ev])}else{pX=cX;pY=cY;ob.hoverIntent_t=setTimeout(function(){compare(ev,ob)},cfg.interval)}};var delay=function(ev,ob){ob.hoverIntent_t=clearTimeout(ob.hoverIntent_t);ob.hoverIntent_s=0;return cfg.out.apply(ob,[ev])};var handleHover=function(e){var ev=jQuery.extend({},e);var ob=this;if(ob.hoverIntent_t){ob.hoverIntent_t=clearTimeout(ob.hoverIntent_t)}if(e.type=="mouseenter"){pX=ev.pageX;pY=ev.pageY;$(ob).bind("mousemove",track);if(ob.hoverIntent_s!=1){ob.hoverIntent_t=setTimeout(function(){compare(ev,ob)},cfg.interval)}}else{$(ob).unbind("mousemove",track);if(ob.hoverIntent_s==1){ob.hoverIntent_t=setTimeout(function(){delay(ev,ob)},cfg.timeout)}}};return this.bind('mouseenter',handleHover).bind('mouseleave',handleHover)}})(jQuery);

--- a/js/system.js
+++ b/js/system.js
@@ -221,7 +221,7 @@ var sidebars = {
 
         // Left Column Slider
         $("#sb-left")
-            .hover(function() {
+            .hoverIntent(function() {
             var timeout_r = $(this)
                 .data("timeout_r");
             if (timeout_r) {
@@ -261,7 +261,7 @@ var sidebars = {
 
         // Right Column Slider
         $("#sb-right")
-            .hover(function() {
+            .hoverIntent(function() {
             var timeout_r = $(this)
                 .data("timeout_r");
             if (timeout_r) {


### PR DESCRIPTION
Implemented on left and right panel swing-outs to add debouncing and dampening when near edges or scrolling.

It has other uses as well, like keeping context menus open for a moment if you mouse-out accidentally

http://cherne.net/brian/resources/jquery.hoverIntent.html

I know jquery ui has some built in hoverintent, I can't find anything on it, it might only be an accordion special event.
