### PR TITLE
Fix for bug when trying to use 'vim' in terminal

### DIFF
--- a/components/terminal/emulator/term.php
+++ b/components/terminal/emulator/term.php
@@ -99,7 +99,7 @@
             }
             
             // Replace text editors with cat
-            $editors = array('vi','vim','nano');
+            $editors = array('vim','vi','nano');
             $this->command = str_replace($editors,'cat',$this->command);
             
             // Handle blocked commands


### PR DESCRIPTION
This fixes the error 'catm command not found' when issuing 'vim foo' in terminal.
'vim' command is now replace by 'cat'. Before, the first match for replace was the substring 'vi' resulting to replacing by the not existing 'catm' command.
This is a very small code change.
