### PR TITLE
Fix uninitialized index in terminal

### DIFF
--- a/components/terminal/emulator/term.php
+++ b/components/terminal/emulator/term.php
@@ -174,7 +174,7 @@
         $_SESSION['term_auth'] = 'false';
         $output = '[CLOSED]';
         
-    }else if($_SESSION['term_auth']!='true'){
+    }else if(! isset($_SESSION['term_auth']) || $_SESSION['term_auth']!='true'){
         
         //////////////////////////////////////////////////////////////
         // Authentication


### PR DESCRIPTION
An erreur append when you start the terminal emulator. 
