### PR TITLE
Update common.php

### DIFF
--- a/common.php
+++ b/common.php
@@ -6,7 +6,8 @@
     */
     
     include BASE_PATH."/languages/english.php"; //english is the main language
-    include BASE_PATH."/languages/{$_SESSION['lang']}.php";
+    if (isset($_SESSION['lang']))
+        include BASE_PATH."/languages/{$_SESSION['lang']}.php";
     
     function i18n($key, $output = true) {
         global $lang;


### PR DESCRIPTION
Minor change to check if the $_SESSION['lang'] is set, and avoid following errors :

> Notice: Undefined index: lang in codiad/common.php on line 10
> Warning: include(/codiad/languages/.php): failed to open stream: No such file or directory in codiad/common.php on line 10
> Warning: include(): Failed opening '/codiad/languages/.php' for inclusion (include_path='.:/usr/share/php:/usr/share/pear') in codiad/common.php on line 10
