### PR TITLE
Adding phtml to supported file extensions for php

### DIFF
--- a/components/editor/init.js
+++ b/components/editor/init.js
@@ -691,6 +691,7 @@
                 return 'less';
             case 'php':
             case 'php5':
+            case 'phtml':
                 return 'php';
             case 'json':
                 return 'json';


### PR DESCRIPTION
phtml is the current standard for ZF2 views
