### PR TITLE
colored scrollbars for IE

### DIFF
--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -45,6 +45,17 @@ html, body {
     overflow: hidden;
 }
 
+div {
+    scrollbar-base-color:#1a1a1a;
+    scrollbar-3d-light-color:#1a1a1a;
+    scrollbar-arrow-color:#303030;
+    scrollbar-darkshadow-color:#303030;
+    scrollbar-face-color:#1a1a1a;
+    scrollbar-highlight-color:#303030;
+    scrollbar-shadow-color:#303030;
+    scrollbar-track-color:#303030;
+}
+
 /* GLOBALS */
 
 a,a:link,a:visited {


### PR DESCRIPTION
scrollbar looks very ugly on IE in Codiad, colored to match default theme
![scrollbar](https://f.cloud.github.com/assets/3989440/376319/2e8c592e-a421-11e2-822d-be4f9d9f4e89.PNG)
