### PR TITLE
fixed issue #308: failure on "Download"

### DIFF
--- a/components/filemanager/download.php
+++ b/components/filemanager/download.php
@@ -11,9 +11,9 @@
     //////////////////////////////////////////////////////////////////
     // Verify Session or Key
     //////////////////////////////////////////////////////////////////
-    
+
     checkSession();
-    
+
     //////////////////////////////////////////////////////////////////
     // Check $_GET for incorrect chars or '..' for workspace ecape
     //////////////////////////////////////////////////////////////////
@@ -25,7 +25,7 @@
     		|| strpos('..', $_GET['path']) !== false ){ // change directory up to escape Workspace
     	exit('<script>parent.codiad.message.error("Wrong data send")</script>');
     }
-    
+
     //////////////////////////////////////////////////////////////////
     // Run Download
     //////////////////////////////////////////////////////////////////
@@ -40,32 +40,32 @@
         if(!is_dir($dir)){
         	exit('<script>parent.codiad.message.error("Directory not found.")</script>');
         }
-        	
+
         //////////////////////////////////////////////////////////////////
         // Check system() command and a non windows OS
         //////////////////////////////////////////////////////////////////
         if(isAvailable('system') && stripos(PHP_OS, 'win') === false){
-	        # Execute the tar command and save file
-        	$filename .= '.tag.gz';
-        	
-        	system("tar -pczf ".$targetPath.$filename." ".$dir);
-	        $download_file = $targetPath.$filename;
+          # Execute the tar command and save file
+          $filename .= '.tar.gz';
+
+          system("tar -pczf ".$targetPath.$filename." ".$dir);
+          $download_file = $targetPath.$filename;
         }elseif(extension_loaded('zip')){ //Check if zip-Extension is availiable
-        	//build zipfile
-        	require_once 'class.dirzip.php';
-        	
-        	$filename .= '.zip';
-        	$download_file = $targetPath.$filename;
-        	DirZip::zipDir($dir, $targetPath .$filename);
+          //build zipfile
+          require_once 'class.dirzip.php';
+
+          $filename .= '.zip';
+          $download_file = $targetPath.$filename;
+          DirZip::zipDir($dir, $targetPath .$filename);
         }else{
-        	exit('<script>parent.codiad.message.error("Could not pack the folder, zip-extension missing")</script>');
+          exit('<script>parent.codiad.message.error("Could not pack the folder, zip-extension missing")</script>');
         }
     }else{
         $filename = explode("/",$_GET['path']);
         $filename = array_pop($filename);
         $download_file = WORKSPACE . $_GET['path'];
     }
-    
+
     header('Content-Description: File Transfer');
     header('Content-Type: application/octet-stream');
     header('Content-Disposition: attachment; filename='.basename($filename));


### PR DESCRIPTION
A javascript error was shown when you try to download a folder from a project.
There was two errors:
1. The workspace path was missing a '/' at the end.
2. The error was not logged properly because the javascript error call was incorrect.
