### PR TITLE
Bugfix: fix for sidebar userlock

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -46,7 +46,7 @@
             $('#modal-content')
                 .html('');
             codiad.sidebars.modalLock = false;
-            if (!codiad.sidebars.userLock) { // Slide sidebar back
+            if (!codiad.sidebars.leftLock) { // Slide sidebar back
                 $('#sb-left')
                     .animate({
                         'left': '-290px'

--- a/js/system.js
+++ b/js/system.js
@@ -71,7 +71,7 @@
 
             var marginL, reduction;
             if ($("#sb-left")
-                .css('left') !== 0 && !codiad.sidebars.userLock) {
+                .css('left') !== 0 && !codiad.sidebars.leftLock) {
                 marginL = handleWidth;
                 reduction = 2 * handleWidth;
             } else {


### PR DESCRIPTION
critical stuff the sidebar ref to https://github.com/Codiad/Codiad/issues/369
- moving leftbar to the left does not resize editor window correctly
- closing a modal popup moves leftbar out of scope
