### PR TITLE
Fix: delete dummy config on install

### DIFF
--- a/components/install/view.php
+++ b/components/install/view.php
@@ -20,6 +20,7 @@ if(!file_exists($conf) && !is_writable($path)) {
     $config = file_put_contents($conf, file_get_contents($path . "/config.example.php"));
     if($config !== false) {
         $config = true;
+        unlink($conf);
     }
 } elseif(file_exists($conf)) {
     $config = is_writable($conf);


### PR DESCRIPTION
If you press F5 during the installation screen, you will be redirected to loginpage, but you are unable to login as the installation does not succeed.

this is only a workaround. 
