### PR TITLE
Fix: comment pmurl by default

### DIFF
--- a/components/install/process.php
+++ b/components/install/process.php
@@ -191,7 +191,7 @@ define("WORKSPACE", BASE_PATH . "/workspace");
 define("WSURL", BASE_URL . "/workspace");
 
 // Plugin Market
-define("PMURL", "http://codiad.com/plugins.json");
+//define("PMURL", "http://codiad.com/plugins.json");
 ';
 
     saveFile($config,$config_data);

--- a/config.example.php
+++ b/config.example.php
@@ -44,5 +44,5 @@ define("WORKSPACE", BASE_PATH . "/workspace");
 define("WSURL", BASE_URL . "/workspace");
 
 // Plugin Market
-define("PMURL", "http://codiad.com/plugins.json");
+//define("PMURL", "http://codiad.com/plugins.json");
 


### PR DESCRIPTION
definition of pmurl should be commented by default and only used if required. Otherwhise we have it statically in config.php and are not able to change it further on as this definition is only required for the use of changing urls to some custom repo
