### PR TITLE
[Collaborative] Regulate Speed of sendSelectionChange posts

### DIFF
--- a/components/collaborative/init.js
+++ b/components/collaborative/init.js
@@ -244,9 +244,8 @@
             // Selection change can be fired 100's of times per second as the mouse drags
             // Got to regulate the interval for optimization
             var now = new Date().getTime();
-            var minInterval = 500;
+            var minInterval = 250;
             if (typeof(this.onSelectionChange.lastSelectionChange) === 'undefined') {
-                console.log("initialize last selection change");
                 this.onSelectionChange.lastSelectionChange = now;
             }
             var interval = now - this.onSelectionChange.lastSelectionChange;
@@ -263,12 +262,10 @@
         },
         
         postSelectionChange: function () {
-            console.log('selection change');
             var post = { action: 'sendSelectionChange',
                 filename: codiad.active.getPath(),
                 selection: JSON.stringify(this._getSelection().getRange()) };
-            // console.log(post);
-
+                
             $.post(this.controller, post, function (data) {
                 // console.log('complete selection change');
                 // console.log(data);


### PR DESCRIPTION
I noticed as you drag the mouse around, it blasts out 100's or more posts to the server per second, this update makes it limit how frequently those can be sent (defined by the minInterval which is 500 now). So in other words, if you are dragging around, once you stop for 500 ms, it will then post the selection coordinates. I do feel this is important to avoid flooding requests to the server, even if you lower the interval way below 500.
