### PR TITLE
Mapped .vm to velocity format.

### DIFF
--- a/components/fileext_textmode/class.fileextension_textmode.php
+++ b/components/fileext_textmode/class.fileextension_textmode.php
@@ -39,7 +39,8 @@ class fileextension_textmode{
 			'py' => 'python',
 			'rb' => 'ruby',
 			'jade' => 'jade',
-			'coffee' => 'coffee');
+			'coffee' => 'coffee',
+			'vm' => 'velocity');
 
 	//////////////////////////////////////////////////////////////////
 	//availiable text modes


### PR DESCRIPTION
Although it originally stands for "Velocity Macro"; the .vm is used for most of the velocity templates files.
