### PR TITLE
make all settings accessible

### DIFF
--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -744,6 +744,8 @@ table [class^="icon-"], [class*=" icon-"] {
     position: fixed;
     top: 15%;
     left: 50%;
+    max-height: 70vh;
+	overflow: auto;
     background: #333;
     z-index: 9999999;
     min-height: 100px;


### PR DESCRIPTION
Makes all settings accessible even if one has a small screen. If `#modal` is too high, a scrollbar appears within `#modal`
