### PR TITLE
Prevent context menu from being overlapped by code panel (Fixes #581)

### DIFF
--- a/themes/default/filemanager/screen.css
+++ b/themes/default/filemanager/screen.css
@@ -82,7 +82,7 @@
     display: none;
     top: 0;
     left: 0;
-    position: absolute;
+    position: fixed;
     width: 140px;
     padding: 0;
     background: #333;


### PR DESCRIPTION
I just learned about this project today but I've already started using it and I gotta say, it's definitely the simplest web-based IDE I've seen yet! So I figured I'd give a little bit (one line's worth) back :)

I was able to fix the context menu issue (#581) just by changing its position to "fixed."

Thanks for such an awesome tool!
