### PR TITLE
Fix bug: when saving 2 or more patches with Save All, first task's patch was used in other tasks

### DIFF
--- a/components/worker_manager/init.js
+++ b/components/worker_manager/init.js
@@ -23,7 +23,10 @@
                         _this.concludeTask(e.data);
                     }, false);
                 }
-                this.scheduleNext();
+
+                if (this.taskQueue.length == 1) {
+                    this.scheduleNext();
+                }
             } else {
                 callback(false,taskConfig.id);
             }


### PR DESCRIPTION
Bug found when saving 2 new files with Save All (was saving both files with whole content).
Then, closed them, reopened them, made changes to both, Saving All (was saving both files with patch at this time).
Then, closed them, reopened them, and realized that second file doesn't have the good content.
