### PR TITLE
Fixes error during remove_all after renaming an opened file

### DIFF
--- a/components/active/init.js
+++ b/components/active/init.js
@@ -642,7 +642,7 @@
                     .text(newPath.substring(1));
                 this.sessions[newPath] = this.sessions[oldPath];
                 this.sessions[newPath].path = newPath;
-                this.sessions[oldPath] = undefined;
+                delete this.sessions[oldPath];
             };
             if (this.sessions[oldPath]) {
                 // A file was renamed


### PR DESCRIPTION
If you rename an opened file and close it later by close all, it throws always an error.
![error](https://cloud.githubusercontent.com/assets/4389878/3559025/11a33e0c-0944-11e4-8194-3c1fd8fc2281.jpg)
