### PR TITLE
Fix: unable to save empty files, js returns File could not be saved

### DIFF
--- a/components/filemanager/class.filemanager.php
+++ b/components/filemanager/class.filemanager.php
@@ -422,9 +422,7 @@ class Filemanager extends Common {
                         //DEBUG : file_put_contents($this->path.".patch", $this->patch);
                     }
 
-                    $writeSuccess = fwrite($file, $this->content);
-                    fclose($file);
-                    if (! $writeSuccess){
+                    if (fwrite($file, $this->content) === false){
                         $this->status = "error";
                         $this->message = "could not write to file";
                     } else {
@@ -435,6 +433,8 @@ class Filemanager extends Common {
                         $this->data = '"mtime":'.filemtime($this->path);
                         $this->status = "success";
                     }
+
+                    fclose($file);
                 }else{
                    $this->status = "error";
                    $this->message = "Cannot Write to File";
@@ -443,6 +443,11 @@ class Filemanager extends Common {
                 $this->status = "error";
                 $this->message = "Not A File";
             }
+        } else {
+          $file = fopen($this->path, 'w');
+          fclose($file);
+          $this->data = '"mtime":'.filemtime($this->path);
+          $this->status = "success";
         }
 
         $this->respond();


### PR DESCRIPTION
When saving an empty file, codiad returned a red message
