### PR TITLE
Wrong icon after rescanning closed folders

### DIFF
--- a/components/filemanager/init.js
+++ b/components/filemanager/init.js
@@ -286,7 +286,7 @@
                         var files = _this.indexFiles;
                         if (files.length > 0) {
                             if (node.parent().children('span').hasClass('plus')) {
-								node.parent().children('span').removeClass('plus').addClass('minus');
+                                node.parent().children('span').removeClass('plus').addClass('minus');
                             }
                             var display = 'display:none;';
                             if (rescan) {


### PR DESCRIPTION
After rescan a closed folder over the contexmenu, there is still the plus icon instead of minus icon.
