### PR TITLE
Fixes history after renaming active files

### DIFF
--- a/components/active/init.js
+++ b/components/active/init.js
@@ -643,6 +643,12 @@
                 this.sessions[newPath] = this.sessions[oldPath];
                 this.sessions[newPath].path = newPath;
                 delete this.sessions[oldPath];
+                //Rename history
+                for (var i = 0; i < this.history.length; i++) {
+                    if (this.history[i] === oldPath) {
+                        this.history[i] = newPath;
+                    }
+                }
             };
             if (this.sessions[oldPath]) {
                 // A file was renamed


### PR DESCRIPTION
Situation: 
- Two or more open files
- Switch several times between different files to  create a history
- Rename active file
- Switch to another open file
- Causes error (prevSession is undefined) on [active.highlightEntry](https://github.com/Codiad/Codiad/blob/master/components/active/init.js#L427-L429)
