### PR TITLE
Fixes wrong tab title after renaming

### DIFF
--- a/components/active/init.js
+++ b/components/active/init.js
@@ -638,8 +638,12 @@
             var switchSessions = function(oldPath, newPath) {
                 var tabThumb = this.sessions[oldPath].tabThumb;
                 tabThumb.attr('data-path', newPath);
+                var title = newPath;
+                if (codiad.project.isAbsPath(newPath)) {
+                    title = newPath.substring(1);
+                }
                 tabThumb.find('.label')
-                    .text(newPath.substring(1));
+                    .text(title);
                 this.sessions[newPath] = this.sessions[oldPath];
                 this.sessions[newPath].path = newPath;
                 delete this.sessions[oldPath];


### PR DESCRIPTION
![1](https://cloud.githubusercontent.com/assets/4389878/4270972/7e002ada-3cd2-11e4-838c-c2ca3aa4621a.png)
![2](https://cloud.githubusercontent.com/assets/4389878/4270971/7df82524-3cd2-11e4-936a-6d01d3947b41.png)

The deletion of the first letter is on absolute path neccessary. The text direction (css property 'direction: rtl;') causes that the file name is always visible. But it causes on strings, which starts with a slash (/)(absolute paths), that the slash is displayed on the end. [Example](http://codepen.io/anon/pen/KjLef)

This behaviour causes the deletion of the first letter on relative paths, if you rename the file.
