### PR TITLE
Fixes project list

### DIFF
--- a/themes/default/project/screen.css
+++ b/themes/default/project/screen.css
@@ -1,14 +1,11 @@
 #project-list {
-    max-height: 300px;
+    max-height: 50vh;
     overflow: auto;
     margin: 15px 0;
 }
 
 .project-wrapper {
-  max-height: 450px; 
   width: 100%; 
-  overflow-y: auto; 
-  overflow-x: hidden;
 }
 
 .project-list-title {


### PR DESCRIPTION
If you have many projects, the project list gets ugly (double scrollbar):
![projectslist1](https://cloud.githubusercontent.com/assets/4389878/4496112/318dc21e-4a62-11e4-9708-03f1e53398c5.png)
After fix:
![projectslist2](https://cloud.githubusercontent.com/assets/4389878/4496118/39e84c04-4a62-11e4-8c34-33e91a210360.png)
