### PR TITLE
Fixes icon font issue

### DIFF
--- a/themes/default/fonts.css
+++ b/themes/default/fonts.css
@@ -135,7 +135,7 @@
 .icon-clock:before { content: "\1f554"; } /* '\1f554' */
 .icon-hourglass:before { content: "\23f3"; } /* '\23f3' */
 .icon-lamp:before { content: "\1f4a1"; } /* '\1f4a1' */
-.icon-light-down:before { content: "\1f505; } /* '\1f505' */
+.icon-light-down:before { content: "\1f505"; } /* '\1f505' */
 .icon-light-up:before { content: "\1f506"; } /* '\1f506' */
 .icon-adjust:before { content: "\25d1"; } /* '\25d1' */
 .icon-block:before { content: "\1f6ab"; } /* '\1f6ab' */


### PR DESCRIPTION
Inserts [missing quotation mark](https://github.com/Codiad/Codiad/blob/master/themes/default/fonts.css#L138) after PR #745. Happens only in FF, not in Chrome.

Before: 
![before](https://cloud.githubusercontent.com/assets/4389878/5554541/15c62daa-8c61-11e4-8ce0-83d5a1abfbbd.png)

After: 
![after](https://cloud.githubusercontent.com/assets/4389878/5554542/1b048eba-8c61-11e4-813e-1572884dd885.png)
