### PR TITLE
DONT PULL: Add more clear default project install labels.

### DIFF
--- a/components/install/view.php
+++ b/components/install/view.php
@@ -95,10 +95,10 @@ if(!$workspace || !$data || !$config || $register){
 
     <hr>
 
-    <label>New Project Name</label>
+    <label>Default Project Display Name <span style="float:right;"><a href="#">?</a></span></label>
     <input type="text" name="project_name" value="<?php echo($autocomplete['project_name']); ?>">
     <?php if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') { ?>
-    <label>Folder Name or Absolute Path</label>
+    <label>Default Project Folder Name or Absolute Path <span style="float:right;"><a href="#" style="color:white">?</a></span></label>
     <input type="text" name="project_path" value="<?php echo($autocomplete['project_path']); ?>">
     <?php }  ?>
     <hr>


### PR DESCRIPTION
The user now knows that the project name is just the default initial project and that the second input field is the folder location or absolute path for the default project.

DO NOT pull this, I want feedback on whether you want to just leave labels as they were and just add "?" links that pull up a help modal as demonstrated. After letting me know, I will make adjustments to this pull request.

#722