### PR TITLE
Make "preview" option ajax call synchronous

### DIFF
--- a/components/filemanager/init.js
+++ b/components/filemanager/init.js
@@ -390,11 +390,15 @@
         //////////////////////////////////////////////////////////////////
 
         openInBrowser: function(path) {
-            $.get(this.controller + '?action=open_in_browser&path=' + path, function(data) {
-                var openIBResponse = codiad.jsend.parse(data);
-                if (openIBResponse != 'error') {
-                    window.open(openIBResponse.url, '_newtab');
-                }
+            $.ajax({
+                url: this.controller + '?action=open_in_browser&path=' + path,
+                success: function(data) {
+                    var openIBResponse = codiad.jsend.parse(data);
+                    if (openIBResponse != 'error') {
+                        window.open(openIBResponse.url, '_newtab');
+                    }
+                },
+                async: false
             });
         },
         openInModal: function(path) {


### PR DESCRIPTION
The "preview" option from the context-menu makes an ajax GET request followed by a "window.open". The popup blocker in most browsers will prevent the "window.open" call from firing, cause it's happening in an asynchronous process.

Making the same call in a synchronous fashion seems to get around this issue.