### PR TITLE
Fix the sidebar title alignment once and for all

### DIFF
--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -96,6 +96,7 @@ a:hover,a:active {;
   font-style: normal;
   font-size: 75%;
   display: inline-block;
+  width: 16px;
   margin-right: 8px;
   text-align: center;
   vertical-align: top;

--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -92,14 +92,17 @@ a:hover,a:active {;
 /* ICONS */
 
 [class^="icon-"], [class*=" icon-"] {
-  font-family: entypo;
-  font-style: normal;
-  font-size: 75%;
-  display: inline-block;
-  width: 16px;
-  margin-right: 8px;
-  text-align: center;
-  vertical-align: top;
+    font-family: entypo;
+    font-style: normal;
+    font-size: 75%;
+    display: inline-block;
+    margin-right: 8px;
+    text-align: center;
+    vertical-align: top;
+}
+
+.sb-right-content [class^="icon-"], .sb-right-content [class*=" icon-"] {
+    width: 16px;
 }
 
 /* Useful size modifiers for icons. */


### PR DESCRIPTION
It may also fix:

/* Fix bad margin at some sizes for icon-doc-text. */
.icon-doc-text {
    padding-right: 3px;
}