### PR TITLE
Fix path variable check in download.php

### DIFF
--- a/components/filemanager/download.php
+++ b/components/filemanager/download.php
@@ -17,7 +17,6 @@
     //////////////////////////////////////////////////////////////////
     // Check $_GET for incorrect chars or '..' for workspace ecape
     //////////////////////////////////////////////////////////////////
-    //FIXME prevent path-variable from beeing something like ././././ which download all projects
     //TODO check if the User is allowed to access the project
     if(!isset($_GET['path']) 
     		|| preg_match('#^[\\\/]?$#i', trim($_GET['path'])) // download all Projects

--- a/components/filemanager/download.php
+++ b/components/filemanager/download.php
@@ -22,7 +22,7 @@
     if(!isset($_GET['path']) 
     		|| preg_match('#^[\\\/]?$#i', trim($_GET['path'])) // download all Projects
     		|| preg_match('#[\:*?\"<>\|]#i', $_GET['path']) //illegal chars in filenames
-    		|| strpos('..', $_GET['path']) !== false ){ // change directory up to escape Workspace
+    		|| substr_count($_GET['path'], './') > 0) { // change directory up to escape Workspace
     	exit('<script>parent.codiad.message.error("Wrong data send")</script>');
     }
 

--- a/components/filemanager/download.php
+++ b/components/filemanager/download.php
@@ -15,7 +15,7 @@
     checkSession();
 
     //////////////////////////////////////////////////////////////////
-    // Check $_GET for incorrect chars or '..' for workspace ecape
+    // Check $_GET for invalid path
     //////////////////////////////////////////////////////////////////
     //TODO check if the User is allowed to access the project
     if(!isset($_GET['path']) 


### PR DESCRIPTION
Reversed parameters on strpos, the needle should be `'./'`, it returns a numeric value and it should be substr_count anyway. 

Fixes ~~[CVE-2014-1137](http://www.exploit-db.com/exploits/35585/) (part 2)~~ excuse me [CVE-2014-9581](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9581) when user is logged in. Tested to not break functionality of project or single file downloads. 

Also fixes the "prevent path-variable from beeing something like ././././ which download all projects" issue, which only seemed to download an empty-yet-size-corresponding file named "download.php" at the time of checking.

This patch prevents an attacker from downloading users.php and other security-related files, including any files the HTTP daemon has access to outside the webroot.