### PR TITLE
Fixes contex menu layout

### DIFF
--- a/components/filemanager/init.js
+++ b/components/filemanager/init.js
@@ -153,10 +153,16 @@
             if (top > $(window).height() - $('#context-menu').height()) {
                 top -= $('#context-menu').height();
             }
+            if (top < 10) {
+                top = 10;
+            }
+            var max = $(window).height() - top - 10;
+            
             $('#context-menu')
                 .css({
                     'top': top + 'px',
-                    'left': e.pageX + 'px'
+                    'left': e.pageX + 'px',
+                    'max-height': max + 'px'
                 })
                 .fadeIn(200)
                 .attr('data-path', path)

--- a/themes/default/filemanager/screen.css
+++ b/themes/default/filemanager/screen.css
@@ -91,6 +91,7 @@
     border: 3px solid rgba(255, 255, 255, 0.5);
     box-shadow: 0px 0px 15px 0px rgba(0, 0, 0, .9);
     border-radius: 3px;
+    overflow-y: scroll;
 }
 #context-menu a {
     display: block;


### PR DESCRIPTION
Better handling for small displays to prevent context menu being off the screen

Before:
![bildschirmfoto 2015-04-10 um 16 35 27](https://cloud.githubusercontent.com/assets/4389878/7106457/e246783c-e141-11e4-9981-ce98ab624351.png)
![bildschirmfoto 2015-04-10 um 16 14 19](https://cloud.githubusercontent.com/assets/4389878/7106459/eb5a46a6-e141-11e4-9b1a-970a268a1d9b.png)

After:
![bildschirmfoto 2015-04-10 um 16 35 11](https://cloud.githubusercontent.com/assets/4389878/7106462/f432467a-e141-11e4-9291-81ac2c56360f.png)
![bildschirmfoto 2015-04-10 um 16 20 44](https://cloud.githubusercontent.com/assets/4389878/7106468/0ff66ab2-e142-11e4-852b-fe830e51da54.png)

