### PR TITLE
Allow plugins to define custom load/unload animations for the modal

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -30,9 +30,7 @@
                     .focus();
             });
             // If a plugin has provided a custom load animation
-            if(typeof codiad.modal.onLoadAnimation == "function") {
-                codiad.modal.onLoadAnimation();
-            } else {
+            if(amplify.publish('modal.onLoad')) {
                 $('#modal, #modal-overlay')
                     .fadeIn(200);
             }
@@ -51,9 +49,7 @@
             // If a plugin has provided a custom unload animation (note
             // that the custom animation function is responsible for removing
             // the HTML from the modal)
-            if(typeof codiad.modal.onUnloadAnimation == "function") {
-                codiad.modal.onUnloadAnimation();
-            } else {
+            if(amplify.publish('modal.onUnload')) {
                 $('#modal, #modal-overlay')
                     .fadeOut(200);
                 $('#modal-content')

--- a/js/modal.js
+++ b/js/modal.js
@@ -29,8 +29,13 @@
                 $('input[autofocus="autofocus"]')
                     .focus();
             });
-            $('#modal, #modal-overlay')
-                .fadeIn(200);
+            // If a plugin has provided a custom load animation
+            if(typeof codiad.modal.onLoadAnimation == "function") {
+                codiad.modal.onLoadAnimation();
+            } else {
+                $('#modal, #modal-overlay')
+                    .fadeIn(200);
+            }
             codiad.sidebars.modalLock = true;
         },
 
@@ -43,10 +48,17 @@
             this._setBounds();
             $('#modal-content form')
                 .die('submit'); // Prevent form bubbling
-            $('#modal, #modal-overlay')
-                .fadeOut(200);
-            $('#modal-content')
-                .html('');
+            // If a plugin has provided a custom unload animation (note
+            // that the custom animation function is responsible for removing
+            // the HTML from the modal)
+            if(typeof codiad.modal.onUnloadAnimation == "function") {
+                codiad.modal.onUnloadAnimation();
+            } else {
+                $('#modal, #modal-overlay')
+                    .fadeOut(200);
+                $('#modal-content')
+                    .html('');
+            }
             codiad.sidebars.modalLock = false;
             if (!codiad.sidebars.leftLock) { // Slide sidebar back
                 $('#sb-left')

--- a/js/modal.js
+++ b/js/modal.js
@@ -29,8 +29,10 @@
                 $('input[autofocus="autofocus"]')
                     .focus();
             });
+            var event = {animationPerformed: false};
+            amplify.publish('modal.onLoad', event);            
             // If no plugin has provided a custom load animation
-            if(amplify.publish('modal.onLoad')) {
+            if(!event.animationPerformed) {
                 $('#modal, #modal-overlay')
                     .fadeIn(200);
             }
@@ -46,8 +48,10 @@
             this._setBounds();
             $('#modal-content form')
                 .die('submit'); // Prevent form bubbling
+            var event = { animationPerformed : false };
+            amplify.publish('modal.onUnload', event);
             // If no plugin has provided a custom unload animation
-            if(amplify.publish('modal.onUnload')) {
+            if(!event.animationPerformed) {
                 $('#modal, #modal-overlay')
                     .fadeOut(200);
                 $('#modal-content')

--- a/js/modal.js
+++ b/js/modal.js
@@ -29,7 +29,7 @@
                 $('input[autofocus="autofocus"]')
                     .focus();
             });
-            // If a plugin has provided a custom load animation
+            // If no plugin has provided a custom load animation
             if(amplify.publish('modal.onLoad')) {
                 $('#modal, #modal-overlay')
                     .fadeIn(200);
@@ -46,9 +46,7 @@
             this._setBounds();
             $('#modal-content form')
                 .die('submit'); // Prevent form bubbling
-            // If a plugin has provided a custom unload animation (note
-            // that the custom animation function is responsible for removing
-            // the HTML from the modal)
+            // If no plugin has provided a custom unload animation
             if(amplify.publish('modal.onUnload')) {
                 $('#modal, #modal-overlay')
                     .fadeOut(200);


### PR DESCRIPTION
I would like to create a plugin that allows custom animations for showing/hiding the modal. These changes lend this capability without having to overwrite codiad.modal.load and/or codiad.modal.unload.