### PR TITLE
Fix of output buffering error (problem with downloading files)

### DIFF
--- a/components/filemanager/download.php
+++ b/components/filemanager/download.php
@@ -73,7 +73,8 @@
     header('Cache-Control: must-revalidate');
     header('Pragma: public');
     header('Content-Length: ' . filesize($download_file));
-    ob_clean();
+    if (ob_get_contents()) 
+        ob_end_clean();
     flush();
     readfile($download_file);
     // Remove temp tarball


### PR DESCRIPTION
When I download file (or directory) by right click -> download, I have ob_clean() error in header of file. With this small fix download function works perfectly.