### PR TITLE
Add *.d to default extension associations

### DIFF
--- a/components/fileext_textmode/class.fileextension_textmode.php
+++ b/components/fileext_textmode/class.fileextension_textmode.php
@@ -35,6 +35,7 @@ class fileextension_textmode{
 			'md' => 'markdown',
 			'c' => 'c_cpp',
 			'cpp' => 'c_cpp',
+			'd' => 'd',
 			'h' => 'c_cpp',
 			'hpp' => 'c_cpp',
 			'py' => 'python',


### PR DESCRIPTION
This request adds support for the syntax highlight for [dlang](https://dlang.org/) by default.