### PR TITLE
Remove old PHP versions from Travis CI tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
 
 env:


### PR DESCRIPTION
This request removes PHP 5.3, 5.4 and 5.5 from Travis CI tester because they are no longer supported.

See: http://php.net/supported-versions.php