### PR TITLE
Secure hashing

### DIFF
--- a/components/user/class.user.php
+++ b/components/user/class.user.php
@@ -214,7 +214,7 @@ class User
 
     private function EncryptPassword()
     {
-        $this->password = sha1(md5($this->password));
+        $this->password = password_hash($this->password);
     }
 
     //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Older passwords will not work.
Note that both SHA1 and md5 have been cracked, so all passwords are 100% insecure now :(

We can't just accept this pull request, right now, we have the same function sha(md5()) for both encrypt and verify

Not to mention, our current function is vulnerable to timing-based attacks

We're gonna have to manually go back in and fix all this. 


I've allowed edits from maintainers, so you may wanna come in here and fix this stuff.