### PR TITLE
minor update

### DIFF
--- a/languages/code.php
+++ b/languages/code.php
@@ -18,6 +18,6 @@ $languages = array(
     "bg" => "Български",
     "tr" => "Türkçe",
     "ja" => "日本語",
-    "nl" => "Dutch"
+    "nl" => "Nederlands"
 );
 ?>


### PR DESCRIPTION
All languages are written in their language except Dutch which is written in English. So 'Dutch' should be 'Nederlands'.