### PR TITLE
Incapsulated definitions of mb_ord and mb_chr into a if(!function_exi…

### DIFF
--- a/lib/diff_match_patch.php
+++ b/lib/diff_match_patch.php
@@ -2071,14 +2071,18 @@ define('Match_MaxBits', PHP_INT_SIZE * 8);
 function charCodeAt($str, $pos) {
 	return mb_ord(mb_substr($str, $pos, 1));
 }
-function mb_ord($v) {
-	$k = mb_convert_encoding($v, 'UCS-2LE', 'UTF-8'); 
-	$k1 = ord(substr($k, 0, 1)); 
-	$k2 = ord(substr($k, 1, 1)); 
-	return $k2 * 256 + $k1; 
+if(!function_exists('mb_ord')) {
+	function mb_ord($v) {
+		$k = mb_convert_encoding($v, 'UCS-2LE', 'UTF-8'); 
+		$k1 = ord(substr($k, 0, 1)); 
+		$k2 = ord(substr($k, 1, 1)); 
+		return $k2 * 256 + $k1; 
+	}
 }
-function mb_chr($num){
-	return mb_convert_encoding('&#'.intval($num).';', 'UTF-8', 'HTML-ENTITIES');
+if(!function_exists('mb_chr')) {
+	function mb_chr($num){
+		return mb_convert_encoding('&#'.intval($num).';', 'UTF-8', 'HTML-ENTITIES');
+	}
 }
 
 /**


### PR DESCRIPTION
The default installation on Termux complained that mb_ord and mb_chr were already defined and the error prevented normal operations like listing of files inside s project or adding a new file.

So I incapsulated definitions of mb_ord and mb_chr into a if(!function_exists('...')) {...} to avoid the error when they are already defined. Modifications has no effect on existing code if those functions are not defined.