### PR TITLE
Update controller.php for php8.1 

### DIFF
--- a/components/filemanager/controller.php
+++ b/components/filemanager/controller.php
@@ -54,7 +54,9 @@ if (!checkPath($_GET['path'])) {
     //////////////////////////////////////////////////////////////////
 
     $Filemanager = new Filemanager($_GET, $_POST, $_FILES);
-    $Filemanager->project = @$_SESSION['project']['path'];
+    //fix for php8.1
+    if(isset($_SESSION['project']['path'])){ $Filemanager->project = @$_SESSION['project']['path']; }
+
 
 switch ($action) {
     case 'index':


### PR DESCRIPTION
fix for php 8.1

php8.1 on Ubuntu gives a spinning wheel and html error 500 to the client. 

log shows; php error log shows me "[Fri Jul 01 20:26:15.328201 2022] [php:error] [pid 732] [client 192.168.122.1:52246] PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /var/www/html/components/filemanager/controller.php:57\nStack trace:\n#0 {main}\n thrown in /var/www/html/components/filemanager/controller.php on line 57, referer: http://192.168.122.68/"

this fix found online https://bestofphp.com/repo/Codiad-Codiad-php-web-applications solved the isse - no 500 errors in the client, and no error in the error log after. 

Haven't tested on any other distro/php versions - looking at the code i think it should simply slot in. 